### PR TITLE
Register AD config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/abnormals_delight/core/ADConfig.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_delight/core/ADConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.abnormals_delight.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -9,6 +10,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class ADConfig {
 
 	public static class Common {
+
+		@ConfigKey("replace_fd_item_group")
 		public final ConfigValue<Boolean> replaceFDItemGroup;
 
 		Common(ForgeConfigSpec.Builder builder) {

--- a/src/main/java/com/minecraftabnormals/abnormals_delight/core/AbnormalsDelight.java
+++ b/src/main/java/com/minecraftabnormals/abnormals_delight/core/AbnormalsDelight.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.abnormals_delight.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.abnormals_delight.core.other.ADCompat;
 import com.minecraftabnormals.abnormals_delight.core.registry.ADModifications;
@@ -35,6 +36,7 @@ public class AbnormalsDelight {
 		});
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, ADConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(AbnormalsDelight.MOD_ID, ADConfig.COMMON);
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.