### PR TITLE
Fix plum wood cutting still using cherry in recipe, and other plum recipe related typos

### DIFF
--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_door.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_door.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_door"
+      "item": "environmental:plum_door"
     }
   ],
   "tool": {
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "envrionmental:plum_planks"
+      "item": "environmental:plum_planks"
     }
   ],
   "conditions": [

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_hanging_sign.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_hanging_sign.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_hanging_sign"
+      "item": "environmental:plum_hanging_sign"
     }
   ],
   "tool": {
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "envrionmental:plum_planks"
+      "item": "environmental:plum_planks"
     }
   ],
   "conditions": [

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_log.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_log.json
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "environmental:stripped_cherry_log"
+      "item": "environmental:stripped_plum_log"
     },
     {
       "item": "farmersdelight:tree_bark"

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_log.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_log.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_log"
+      "item": "environmental:plum_log"
     }
   ],
   "tool": {

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_sign.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_sign.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_sign"
+      "item": "environmental:plum_sign"
     }
   ],
   "tool": {
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "envrionmental:plum_planks"
+      "item": "environmental:plum_planks"
     }
   ],
   "conditions": [

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_trapdoor.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_trapdoor.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_trapdoor"
+      "item": "environmental:plum_trapdoor"
     }
   ],
   "tool": {
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "envrionmental:plum_planks"
+      "item": "environmental:plum_planks"
     }
   ],
   "conditions": [

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_wood.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_wood.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "envrionmental:plum_wood"
+      "item": "environmental:plum_wood"
     }
   ],
   "tool": {

--- a/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_wood.json
+++ b/src/main/resources/data/abnormals_delight/recipes/environmental/cutting/plum_wood.json
@@ -11,7 +11,7 @@
   },
   "result": [
     {
-      "item": "environmental:stripped_cherry_wood"
+      "item": "environmental:stripped_plum_wood"
     },
     {
       "item": "farmersdelight:tree_bark"


### PR DESCRIPTION
These two cutting recipes still use the old cherry wood ids as a result rather than the plum wood it has now become.